### PR TITLE
Bug fix: ANSI::BBCode.ansi_to_bbcode

### DIFF
--- a/lib/ansi/bbcode.rb
+++ b/lib/ansi/bbcode.rb
@@ -107,11 +107,8 @@ module ANSI
 
         ## Iterate over input lines
         string.split("\n").each do |line|
-            ansi = line.scan(/\e\[[0-9;]+m/)
-            continue if ansi.nil? || ansi.empty?
-
             ## Iterate over found ansi sequences
-            ansi.each do |seq|
+            line.scan(/\e\[[0-9;]+m/).each do |seq|
                 ansiname = ANSINAME2CODE.invert["#{seq}"]
 
                 ## Pop last tag and form closing tag
@@ -127,7 +124,7 @@ module ANSI
 
                 ## Replace ansi sequence by BBCode tag
                 replace = sprintf("[%s]", bbname)
-                line.sub!("#{Regexp.quote(seq)}", replace)
+                line.sub!(seq, replace)
             end
 
             ## Append converted line

--- a/test/test_bbcode.rb
+++ b/test/test_bbcode.rb
@@ -15,5 +15,15 @@ class TC_BBCode < Test::Unit::TestCase
     assert_equal( out, ANSI::BBCode.bbcode_to_html(str) )
   end
 
+  def test_ansi_to_html
+    str = "this is \e[0;31mred\e[0m, this is \e[1mbold\e[0m\n" +
+          "this is a line without any ansi code\n" +
+          "this is \e[0;31mred\e[0m, this is \e[1mbold\e[0m\n"
+    out = "this is <font color=\"red\">red</font>, this is <strong>bold</strong><br />\n" +
+          "this is a line without any ansi code<br />\n" +
+          "this is <font color=\"red\">red</font>, this is <strong>bold</strong><br />\n"
+    assert_equal( out, ANSI::BBCode.ansi_to_html(str) )
+  end
+
 end
 


### PR DESCRIPTION
Hi,
ANSI::BBCode.ansi_to_bbcode (and thus ansi_to_html) was broken.
And it also had a problem of omitting lines without any ansi code.
Fixed it and added a test case for it to test/test_bbcode.rb
Tested on Ruby 1.9.2.

Cheers,
Junegunn Choi.
