### PR TITLE
rdoc formatting snafu in LICENSE file

### DIFF
--- a/LICENSE.rdoc
+++ b/LICENSE.rdoc
@@ -60,14 +60,14 @@
 
          a) place your modifications in the Public Domain or otherwise
             make them Freely Available, such as by posting said
-	    modifications to Usenet or an equivalent medium, or by allowing
-	    the author to include your modifications in the software.
+            modifications to Usenet or an equivalent medium, or by allowing
+            the author to include your modifications in the software.
 
          b) use the modified software only within your corporation or
             organization.
 
          c) rename any non-standard executables so the names do not conflict
-	    with standard executables, which must also be provided.
+            with standard executables, which must also be provided.
 
          d) make other distribution arrangements with the author.
 
@@ -75,11 +75,11 @@
        form, provided that you do at least ONE of the following:
 
          a) distribute the executables and library files of the software,
-	    together with instructions (in the manual page or equivalent)
-	    on where to get the original distribution.
+            together with instructions (in the manual page or equivalent)
+            on where to get the original distribution.
 
          b) accompany the distribution with the machine-readable source of
-	    the software.
+            the software.
 
          c) give non-standard executables non-standard names, with
             instructions on where to get the original software distribution.


### PR DESCRIPTION
Removed some \t characters that were screwing up rdoc formatting in the LICENSE file.
