### PR TITLE
More Better Table Alignment Options

### DIFF
--- a/lib/ansi/table.rb
+++ b/lib/ansi/table.rb
@@ -69,7 +69,7 @@ module ANSI
       table.each_with_index do |row, r|
          body_row = []
          row.each_with_index do |cell, c|
-           t = cell_template(max[c])
+           t = cell_template(r, c, max[c])
            s = t % cell.to_s
            body_row << apply_format(s, cell, c, r)
          end
@@ -120,8 +120,22 @@ module ANSI
     end
 
     #
-    def cell_template(max)
-      case align
+    def cell_template(row, col, max)
+      _align = nil
+      if align.class==Array
+        _align = align[col]
+        if _align.class==Hash
+          _align.each do |range,alignment|
+            range = (range.begin..1.0/0) if range.end == -1
+            _align=alignment if range.member? row
+          end
+        else
+          _align = nil
+        end
+      else
+        _align = align
+      end
+      case _align
       when :right, 'right'
         "#{@pad}%#{max}s"
       else

--- a/qed/08_table.rdoc
+++ b/qed/08_table.rdoc
@@ -25,4 +25,24 @@ The output will be:
   | 50 | 40 | 20 |
   +----+----+----+
 
+Also supports some limited custom-alignments:
 
+  data = [
+    [ 'Foo', 'Bar', 'Baaz' ],
+    [ 'Josef Stalin', 'Leon Trotsky', 'Nikita Kruschev' ],
+    [ 'Franklin Roosevelt', 'Lyndon Johnson', 'Ronald Reagan' ]
+  ]
+  
+  table = ANSI::Table.new(data, :align=>[:left, {(1..-1)=>:right}, {(1..-1)=>:right}])
+  table.to_s
+  
+Which will output:
+
+  +--------------------+----------------+-----------------+
+  | Foo                | Bar            | Baaz            |
+  | Josef Stalin       |   Leon Trotsky | Nikita Kruschev |
+  | Franklin Roosevelt | Lyndon Johnson |   Ronald Reagan |
+  +--------------------+----------------+-----------------+
+
+  
+  


### PR DESCRIPTION
I had this random desire to have just some columns right-aligned, and even beyond that a still weirder desire to have just some parts of those columns right-aligned.

The result is this. It uses `Range` and some funky stuff to allow you to tell it to align things certain ways. It's not precisely the most flashy of all possible implementations, but if you can think of an improvement I'm happy to iterate until it becomes worthy of being merged into master.

(See the documentation changes, which is where I've illustrated how it looks different; I don't think it'll break any existing code, however - correct me if I'm wrong!)

Thanks for the great gem - saved me a bunch of work there buddy! Keep being awesome!
