### PR TITLE
Update chart.rb - duplicate keys in ANSI::CHART 

### DIFF
--- a/lib/ansi/chart.rb
+++ b/lib/ansi/chart.rb
@@ -26,7 +26,6 @@ module ANSI
     :concealed        => 8,
     :swap             => 7,
     :conceal          => 8,
-    :concealed        => 8,
     :hide             => 9,
     :strike           => 9,
 


### PR DESCRIPTION
Removed duplicate concealed key from line 29