### PR TITLE
Remove duplicated key from hash

### DIFF
--- a/lib/ansi/chart.rb
+++ b/lib/ansi/chart.rb
@@ -23,7 +23,6 @@ module ANSI
     :inverse          => 7,
     :reverse          => 7,
     :negative         => 7,
-    :concealed        => 8,
     :swap             => 7,
     :conceal          => 8,
     :concealed        => 8,


### PR DESCRIPTION
:concealed was present twice (and with the same value) - ruby 2.2 emits warnings in this case
