### PR TITLE
Fix warning under Ruby 2.2.0

### DIFF
--- a/lib/ansi/chart.rb
+++ b/lib/ansi/chart.rb
@@ -23,7 +23,6 @@ module ANSI
     :inverse          => 7,
     :reverse          => 7,
     :negative         => 7,
-    :concealed        => 8,
     :swap             => 7,
     :conceal          => 8,
     :concealed        => 8,


### PR DESCRIPTION
Fixes this warning after `require 'ansi'` under Ruby 2.2:

/home/ari/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/ansi-1.4.3/lib/ansi/chart.rb:26: warning: duplicated key at line 29 ignored: :concealed
