### PR TITLE
Fix warning for duplicate key under Ruby 2.2.0.

### DIFF
--- a/lib/ansi/chart.rb
+++ b/lib/ansi/chart.rb
@@ -26,7 +26,6 @@ module ANSI
     :concealed        => 8,
     :swap             => 7,
     :conceal          => 8,
-    :concealed        => 8,
     :hide             => 9,
     :strike           => 9,
 


### PR DESCRIPTION
Warning was:

```
warning: duplicated key at line 29 ignored: :concealed
```