### PR TITLE
Fix color_on_color methods for 1-argument calls

### DIFF
--- a/lib/ansi/code.rb
+++ b/lib/ansi/code.rb
@@ -72,7 +72,7 @@ module ANSI
             if string
               return string unless $ansi
               #warn "use ANSI block notation for future versions"
-              return #{color.upcase} + ON_#{color.upcase} + string + ENDCODE
+              return #{color.upcase} + ON_#{on_color.upcase} + string + ENDCODE
             end
             if block_given?
               return yield unless $ansi

--- a/test/case_ansicode.rb
+++ b/test/case_ansicode.rb
@@ -31,6 +31,26 @@ testcase ANSI::Code do
     end
   end
 
+  method :red_on_blue do
+    test do
+      str = ANSI::Code.red_on_blue
+      out = "\e[31m\e[44m"
+      out.assert == str
+    end
+
+    test "with block notation" do
+      str = ANSI::Code.red_on_blue { "Lemon" }
+      out = "\e[31m\e[44mLemon\e[0m"
+      out.assert == str
+    end
+
+    test "with positional argument" do
+      str = ANSI::Code.red_on_blue("Cakes")
+      out = "\e[31m\e[44mCakes\e[0m"
+      out.assert == str
+    end
+  end
+
   method :hex do
     test do
       str = ANSI::Code.hex("#000000")


### PR DESCRIPTION
Use the on_color variable for the background color.

``` ruby
# Before:
ANSI.white_on_blue('hello') # => "\e[37m\e[47mhello\e[0m"
# After:
ANSI.white_on_blue('hello') # => "\e[37m\e[44mhello\e[0m"
```
