### PR TITLE
Remove win32console requirement in ruby 2.0.0 and higher

### DIFF
--- a/lib/ansi/code.rb
+++ b/lib/ansi/code.rb
@@ -6,7 +6,7 @@ module ANSI
   # NOTE: This has no effect on methods that return ANSI codes.
   $ansi = true
 
-  if RUBY_PLATFORM =~ /(win32|w32)/
+  if RUBY_VERSION < '2' && RUBY_PLATFORM =~ /(win32|w32)/
     begin
       require 'Win32/Console/ANSI'
     rescue LoadError


### PR DESCRIPTION
This allows ansi to color output in windows with ruby 2+ without attempting to load win32console

The win32console gem is no longer required for ruby 2 or higher in Windows. 
See: https://github.com/luislavena/win32console/issues/17#issuecomment-20811539
