### PR TITLE
Suppress unused variable warnings for Win32 and termios calls

### DIFF
--- a/lib/ansi/terminal/termios.rb
+++ b/lib/ansi/terminal/termios.rb
@@ -53,7 +53,7 @@ module ANSI
         tiocgwinsz = 0x5413
         data = [0, 0, 0, 0].pack("SSSS")
         if out.ioctl(tiocgwinsz, data) >= 0 then
-          rows, cols, xpixels, ypixels = data.unpack("SSSS")
+          _rows, cols, _xpixels, _ypixels = data.unpack("SSSS")
           if cols >= 0 then cols else default_width end
         else
           default_width

--- a/lib/ansi/terminal/win32.rb
+++ b/lib/ansi/terminal/win32.rb
@@ -29,7 +29,7 @@ module ANSI
     def terminal_size
       stdout_handle = GetStdHandle(STD_OUTPUT_HANDLE)
 
-      bufx, bufy, curx, cury, wattr, left, top, right, bottom, maxx, maxy =
+      _bufx, _bufy, _curx, _cury, _wattr, left, top, right, bottom, _maxx, _maxy =
         GetConsoleScreenBufferInfo(stdout_handle)
       return right - left + 1, bottom - top + 1
     end
@@ -45,7 +45,7 @@ module ANSI
           mode &= ~ENABLE_ECHO_INPUT
       end
 
-      ok = SetConsoleMode(console_handle, mode)
+      SetConsoleMode(console_handle, mode)
     end
 
     # win32 console APIs


### PR DESCRIPTION
When running on newer versions of Ruby there's a few `assigned but unused variable` warnings, this change fixes them by prefixing them with `_`

```
/Users/dougedey/.gem/ruby/2.7.2/gems/ansi-1.5.0/lib/ansi/terminal/win32.rb:32: warning: assigned but unused variable - bufx
/Users/dougedey/.gem/ruby/2.7.2/gems/ansi-1.5.0/lib/ansi/terminal/win32.rb:32: warning: assigned but unused variable - bufy
/Users/dougedey/.gem/ruby/2.7.2/gems/ansi-1.5.0/lib/ansi/terminal/win32.rb:32: warning: assigned but unused variable - curx
/Users/dougedey/.gem/ruby/2.7.2/gems/ansi-1.5.0/lib/ansi/terminal/win32.rb:32: warning: assigned but unused variable - cury
/Users/dougedey/.gem/ruby/2.7.2/gems/ansi-1.5.0/lib/ansi/terminal/win32.rb:32: warning: assigned but unused variable - wattr
/Users/dougedey/.gem/ruby/2.7.2/gems/ansi-1.5.0/lib/ansi/terminal/win32.rb:32: warning: assigned but unused variable - maxx
/Users/dougedey/.gem/ruby/2.7.2/gems/ansi-1.5.0/lib/ansi/terminal/win32.rb:32: warning: assigned but unused variable - maxy
/Users/dougedey/.gem/ruby/2.7.2/gems/ansi-1.5.0/lib/ansi/terminal/win32.rb:48: warning: assigned but unused variable - ok
/Users/dougedey/.gem/ruby/2.7.2/gems/ansi-1.5.0/lib/ansi/terminal/termios.rb:56: warning: assigned but unused variable - rows
/Users/dougedey/.gem/ruby/2.7.2/gems/ansi-1.5.0/lib/ansi/terminal/termios.rb:56: warning: assigned but unused variable - xpixels
/Users/dougedey/.gem/ruby/2.7.2/gems/ansi-1.5.0/lib/ansi/terminal/termios.rb:56: warning: assigned but unused variable - ypixels
```

I'm not sure if this Gem is still owned, or what the release process is, so I'm happy for feedback if things I haven't done correctly